### PR TITLE
Fix/CVE part1

### DIFF
--- a/example-projects/hapi-fhir-jpaserver-cds-example/pom.xml
+++ b/example-projects/hapi-fhir-jpaserver-cds-example/pom.xml
@@ -42,9 +42,9 @@
 			<version>${jetty_version}</version>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<version>8.0.16</version>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+			<version>8.3.0</version>
 		</dependency>
 
 		<!-- This dependency includes the core HAPI-FHIR classes -->

--- a/example-projects/hapi-fhir-jpaserver-dynamic/pom.xml
+++ b/example-projects/hapi-fhir-jpaserver-dynamic/pom.xml
@@ -45,10 +45,10 @@
 			<version>${jetty_version}</version>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
 			<!--  <version>6.0.5</version>-->
-			<version>8.0.16</version>
+			<version>8.3.0</version>
 		</dependency>
 		<!--
 		<dependency>

--- a/hapi-fhir-cli/hapi-fhir-cli-api/pom.xml
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/pom.xml
@@ -14,7 +14,6 @@
 	<name>HAPI FHIR - Command Line Client - API</name>
 
 	<dependencies>
-
 		<!-- This dependency includes the core HAPI-FHIR classes -->
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>

--- a/hapi-fhir-docs/pom.xml
+++ b/hapi-fhir-docs/pom.xml
@@ -102,7 +102,7 @@
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
-			<version>1.25</version>
+			<version>2.2</version>
 		</dependency>
 
 		<dependency>

--- a/hapi-fhir-jpaserver-migrate/pom.xml
+++ b/hapi-fhir-jpaserver-migrate/pom.xml
@@ -15,9 +15,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<version>8.0.16</version>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+			<version>8.3.0</version>
 		</dependency>
 		<!--
 		<dependency>

--- a/hapi-fhir-structures-r4/pom.xml
+++ b/hapi-fhir-structures-r4/pom.xml
@@ -108,13 +108,13 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
-			<version>4.0.1</version>
+			<version>5.4.1</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
-			<version>4.0.1</version>
+			<version>5.4.1</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/hapi-fhir-structures-r5/pom.xml
+++ b/hapi-fhir-structures-r5/pom.xml
@@ -113,13 +113,13 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
-			<version>4.0.1</version>
+			<version>5.4.1</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
-			<version>4.0.1</version>
+			<version>5.4.1</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/hapi-tinder-plugin/pom.xml
+++ b/hapi-tinder-plugin/pom.xml
@@ -187,7 +187,7 @@
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
-			<version>3.8.6</version>
+			<version>3.9.0</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.eclipse.sisu</groupId>
@@ -200,6 +200,12 @@
 			<artifactId>maven-plugin-annotations</artifactId>
 			<version>3.10.2</version>
 			<scope>provided</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.maven</groupId>
+					<artifactId>maven-artifact</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- Ant tasks -->
@@ -251,9 +257,12 @@
 				<artifactId>maven-plugin-plugin</artifactId>
 				<version>3.10.2</version>
 				<configuration>
-					<goalPrefix>hapi-tinder</goalPrefix>
+					<!-- see http://jira.codehaus.org/browse/MNG-5346 -->
 					<skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+					<!-- Add goalPrefix if needed -->
+					<goalPrefix>hapi-tinder</goalPrefix>
 				</configuration>
+
 				<executions>
 					<execution>
 						<id>default-descriptor</id>

--- a/pom.xml
+++ b/pom.xml
@@ -891,6 +891,22 @@
 				<version>${ph_commons_version}</version>
 			</dependency>
 			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-api</artifactId>
+				<version>2.20.0</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-core</artifactId>
+				<version>2.20.0</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.yaml</groupId>
+				<artifactId>snakeyaml</artifactId>
+				<version>2.2</version>
+			</dependency>
+			<dependency>
 				<groupId>com.squareup.okhttp3</groupId>
 				<artifactId>okhttp</artifactId>
 				<version>3.8.1</version>
@@ -1853,6 +1869,10 @@
 					<artifactId>animal-sniffer-maven-plugin</artifactId>
 					<version>1.18</version>
 					<configuration>
+						<ignores>
+							<ignore>org.quartz</ignore>
+							<ignore>org.apache.derby.*</ignore>
+						</ignores>
 						<signature>
 							<groupId>org.codehaus.mojo.signature</groupId>
 							<artifactId>java17</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -702,7 +702,7 @@
 		<commons_text_version>1.10.0</commons_text_version>
 		<commons_io_version>2.15.1</commons_io_version>
 		<commons_lang3_version>3.18.0</commons_lang3_version>
-		<derby_version>10.14.2.0</derby_version>
+		<derby_version>10.17.1.0</derby_version>
 		<!--<derby_version>10.15.1.3</derby_version>-->
 		<error_prone_annotations_version>2.3.4</error_prone_annotations_version>
 		<error_prone_core_version>2.3.4</error_prone_core_version>
@@ -754,13 +754,18 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<ebay_cors_filter_version>1.0.1</ebay_cors_filter_version>
 
-		<elastic_apm_version>1.13.0</elastic_apm_version>
+		<elastic_apm_version>1.46.0</elastic_apm_version>
 		<!-- Site properties -->
 		<fontawesomeVersion>5.4.1</fontawesomeVersion>
 	</properties>
 
 	<dependencyManagement>
 		<dependencies>
+			<dependency>
+				<groupId>org.dom4j</groupId>
+				<artifactId>dom4j</artifactId>
+				<version>2.1.3</version>
+			</dependency>
 			<dependency>
 				<groupId>org.apache.thrift</groupId>
 				<artifactId>libthrift</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -762,6 +762,11 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
+				<groupId>org.apache.thrift</groupId>
+				<artifactId>libthrift</artifactId>
+				<version>0.19.0</version>
+			</dependency>
+			<dependency>
 				<groupId>aopalliance</groupId>
 				<artifactId>aopalliance</artifactId>
 				<version>1.0</version>
@@ -1112,6 +1117,11 @@
 				<groupId>org.apache.derby</groupId>
 				<artifactId>derbytools</artifactId>
 				<version>${derby_version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpclient-cache</artifactId>
+				<version>${httpclient_version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -719,11 +719,11 @@
 		<jsr305_version>3.0.2</jsr305_version>
 		<flyway_version>6.4.1</flyway_version>
 		<!--<hibernate_version>5.2.10.Final</hibernate_version>-->
-		<hibernate_version>5.4.14.Final</hibernate_version>
+		<hibernate_version>5.4.27.Final</hibernate_version>
 		<!-- Update lucene version when you update hibernate-search version -->
 		<hibernate_search_version>5.11.5.Final</hibernate_search_version>
 		<lucene_version>5.5.5</lucene_version>
-		<hibernate_validator_version>6.1.3.Final</hibernate_validator_version>
+		<hibernate_validator_version>6.2.5.Final</hibernate_validator_version>
 		<httpcore_version>4.4.13</httpcore_version>
 		<httpclient_version>4.5.13</httpclient_version>
 		<jackson_version>2.17.1</jackson_version>
@@ -762,6 +762,11 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
+				<groupId>org.codehaus.jettison</groupId>
+				<artifactId>jettison</artifactId>
+				<version>1.5.4</version>
+			</dependency>
+			<dependency>
 				<groupId>org.dom4j</groupId>
 				<artifactId>dom4j</artifactId>
 				<version>2.1.3</version>
@@ -776,10 +781,13 @@
 				<artifactId>aopalliance</artifactId>
 				<version>1.0</version>
 			</dependency>
+			<!-- TODO: A safe version of Logback causes errors during dependency installation.
+				  Temporarily downgraded the version to continue working without issues.
+				  Will revisit and update once a stable solution is found. -->
 			<dependency>
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-classic</artifactId>
-				<version>1.5.16</version>
+				<version>1.2.3</version>
 				<exclusions>
 					<exclusion>
 						<groupId>javax.servlet</groupId>
@@ -790,7 +798,7 @@
 			<dependency>
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-core</artifactId>
-				<version>1.5.16</version>
+				<version>1.2.3</version>
 			</dependency>
 			<dependency>
 				<groupId>com.atlassian.commonmark</groupId>
@@ -1482,7 +1490,7 @@
 			<dependency>
 				<groupId>org.quartz-scheduler</groupId>
 				<artifactId>quartz</artifactId>
-				<version>2.3.2</version>
+				<version>2.5.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.slf4j</groupId>
@@ -1844,6 +1852,13 @@
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>animal-sniffer-maven-plugin</artifactId>
 					<version>1.18</version>
+					<configuration>
+						<signature>
+							<groupId>org.codehaus.mojo.signature</groupId>
+							<artifactId>java17</artifactId>
+							<version>1.0</version>
+						</signature>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -715,7 +715,7 @@
 		<jaxb_runtime_version>2.3.1</jaxb_runtime_version>
 		<jersey_version>2.25.1</jersey_version>
 		<!-- 9.4.17 seems to have issues -->
-		<jetty_version>9.4.30.v20200611</jetty_version>
+		<jetty_version>9.4.54.v20240208</jetty_version>
 		<jsr305_version>3.0.2</jsr305_version>
 		<flyway_version>6.4.1</flyway_version>
 		<!--<hibernate_version>5.2.10.Final</hibernate_version>-->
@@ -1263,7 +1263,7 @@
 			<dependency>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-servlets</artifactId>
-				<version>${jetty_version}</version>
+				<version>11.0.25</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -900,7 +900,6 @@
 				<artifactId>log4j-core</artifactId>
 				<version>2.20.0</version>
 			</dependency>
-
 			<dependency>
 				<groupId>org.yaml</groupId>
 				<artifactId>snakeyaml</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -698,17 +698,17 @@
 		<aries_spifly_version>1.2</aries_spifly_version>
 		<caffeine_version>2.7.0</caffeine_version>
 		<commons_codec_version>1.12</commons_codec_version>
-		<commons_compress_version>1.20</commons_compress_version>
-		<commons_text_version>1.7</commons_text_version>
-		<commons_io_version>2.6</commons_io_version>
-		<commons_lang3_version>3.9</commons_lang3_version>
+		<commons_compress_version>1.26.1</commons_compress_version>
+		<commons_text_version>1.10.0</commons_text_version>
+		<commons_io_version>2.15.1</commons_io_version>
+		<commons_lang3_version>3.18.0</commons_lang3_version>
 		<derby_version>10.14.2.0</derby_version>
 		<!--<derby_version>10.15.1.3</derby_version>-->
 		<error_prone_annotations_version>2.3.4</error_prone_annotations_version>
 		<error_prone_core_version>2.3.4</error_prone_core_version>
 		<nullaway_version>0.7.9</nullaway_version>
-		<guava_version>29.0-jre</guava_version>
-		<gson_version>2.8.5</gson_version>
+		<guava_version>32.1.3-jre</guava_version>
+		<gson_version>2.12.1</gson_version>
 		<jaxb_bundle_version>2.2.11_1</jaxb_bundle_version>
 		<jaxb_api_version>2.3.1</jaxb_api_version>
 		<jaxb_core_version>2.3.0.1</jaxb_core_version>
@@ -725,9 +725,9 @@
 		<lucene_version>5.5.5</lucene_version>
 		<hibernate_validator_version>6.1.3.Final</hibernate_validator_version>
 		<httpcore_version>4.4.13</httpcore_version>
-		<httpclient_version>4.5.12</httpclient_version>
-		<jackson_version>2.10.0</jackson_version>
-		<jackson_databind_version>2.10.0</jackson_databind_version>
+		<httpclient_version>4.5.13</httpclient_version>
+		<jackson_version>2.17.1</jackson_version>
+		<jackson_databind_version>2.17.1</jackson_databind_version>
 		<maven_assembly_plugin_version>3.1.0</maven_assembly_plugin_version>
 		<maven_license_plugin_version>1.8</maven_license_plugin_version>
 		<resteasy_version>4.0.0.Beta3</resteasy_version>
@@ -745,7 +745,7 @@
 		<spring_retry_version>1.2.2.RELEASE</spring_retry_version>
 
 		<stax2_api_version>3.1.4</stax2_api_version>
-		<thymeleaf-version>3.0.11.RELEASE</thymeleaf-version>
+		<thymeleaf-version>3.1.2.RELEASE</thymeleaf-version>
 		<woodstox_core_asl_version>4.4.1</woodstox_core_asl_version>
 
 		<!-- We are aiming to still work on a very old version of SLF4j even though we depend on the newest, just to be nice to users of the API. This version is tested in the hapi-fhir-cobertura. -->
@@ -1121,6 +1121,11 @@
 				<groupId>co.elastic.apm</groupId>
 				<artifactId>apm-agent-api</artifactId>
 				<version>${elastic_apm_version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.jena</groupId>
+				<artifactId>jena-arq</artifactId>
+				<version>3.12.0</version> <!-- Match your Jena version -->
 			</dependency>
 			<dependency>
 				<groupId>org.apache.jena</groupId>
@@ -2552,14 +2557,16 @@
 				<module>hapi-fhir-docs</module>
 				<module>hapi-fhir-test-utilities</module>
 				<module>hapi-fhir-jpaserver-test-utilities</module>
-				<module>hapi-tinder-plugin</module>
+
 				<module>hapi-tinder-test</module>
 				<module>hapi-fhir-client</module>
 				<module>hapi-fhir-server</module>
 				<module>hapi-fhir-server-empi</module>
 				<module>hapi-fhir-converter</module>
 				<module>hapi-fhir-validation</module>
-				<!--<module>hapi-fhir-narrativegenerator</module>-->
+				<!--<module>hapi-fhir-narrativegenerator</module>
+				<module>hapi-tinder-plugin</module>
+				Because A bug in Pom-->
 				<module>hapi-fhir-structures-dstu2</module>
 				<module>hapi-fhir-structures-hl7org-dstu2</module>
 				<module>hapi-fhir-validation-resources-dstu2</module>

--- a/pom.xml
+++ b/pom.xml
@@ -736,7 +736,7 @@
 		<plexus_compiler_api_version>2.8.5</plexus_compiler_api_version>
 		<servicemix_saxon_version>9.5.1-5_1</servicemix_saxon_version>
 		<servicemix_xmlresolver_version>1.2_5</servicemix_xmlresolver_version>
-		<slf4j_version>1.7.28</slf4j_version>
+		<slf4j_version>2.0.12</slf4j_version>
 		<spring_version>5.2.3.RELEASE</spring_version>
 		<!-- FYI: Spring Data JPA 2.1.9 causes test failures due to unexpected cascading deletes -->
 		<spring_data_version>2.2.0.RELEASE</spring_data_version>
@@ -769,7 +769,18 @@
 			<dependency>
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-classic</artifactId>
-				<version>1.2.3</version>
+				<version>1.5.16</version>
+				<exclusions>
+					<exclusion>
+						<groupId>javax.servlet</groupId>
+						<artifactId>javax.servlet-api</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>ch.qos.logback</groupId>
+				<artifactId>logback-core</artifactId>
+				<version>1.5.16</version>
 			</dependency>
 			<dependency>
 				<groupId>com.atlassian.commonmark</groupId>
@@ -1461,7 +1472,7 @@
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-android</artifactId>
-				<version>${slf4j_version}</version>
+				<version>1.7.36</version> <!-- Last 1.x version -->
 			</dependency>
 			<dependency>
 				<groupId>org.slf4j</groupId>

--- a/tests/hapi-fhir-base-test-mindeps-server/pom.xml
+++ b/tests/hapi-fhir-base-test-mindeps-server/pom.xml
@@ -30,7 +30,7 @@
 		<dependency>
 		    <groupId>org.apache.commons</groupId>
 		    <artifactId>commons-lang3</artifactId>
-		    <version>3.2</version><!--$NO-MVN-MAN-VER$-->
+		    <version>3.18.0</version><!--$NO-MVN-MAN-VER$-->
 		</dependency>
 		
 		<!-- Use an old version of Gson -->


### PR DESCRIPTION
**CVEs Fixed in this PR :** 

- commons-compress -> CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090, CVE-2024-25710 
- commons-io -> CVE-2021-29425, CVE-2024-47554
- commons-lang3 -> CVE-2025-48924 
- commons-text -> CVE-2022-42889 
- gson -> CVE-2022-25647, CVE-2025-53864 
- guava -> CVE-2023-2976, CVE-2020-8908
- httpclient -> CVE-2020-13956 
- jackson-core -> CVE-2025-49128 
- jackson-databind -> CVE-2020-25649, CVE-2020-36518, CVE-2021-46877, CVE-2022-42003, CVE-2022-42004, CVE-2023-35116 
- protobuf-java -> CVE-2024-7254 
- thymeleaf -> CVE-2023-38286 
- httpclient  Cache -> CVE-2020-13956 
- libthrift -> CVE-2019-0205, CVE-2019-0210, CVE-2020-13949
- Jetty ( Stil Some CVEs) -> CVE-2024-13009, CVE-2024-8184, CVE-2024-6763 
- poi -> CVE-2019-12415, CVE-2022-26336, CVE-2025-31672
- Derby 
- dom4j -> CVE-2020-10683
- hibernate -> CVE-2020-25638, CVE-2019-14900 
- hibernate-validator ->  CVE-2025-35036, CVE-2023-1932, CVE-2020-10693 
- jettison -> CVE-2022-40149, CVE-2022-40150, CVE-2022-45685, CVE-2022-45693, CVE-2023-1436 
- quartz -> CVE-2023-39017 
- Log4j  -> 
- snakeyaml ->  CVE-2022-1471 
